### PR TITLE
Fix typo and captureException bug

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -2,7 +2,7 @@ winston-transport-sentry
 ========================
 
 
-### Compitable
+### Compatible
 Winston@3+
 
 

--- a/index.js
+++ b/index.js
@@ -86,7 +86,7 @@ class SentryWinstonTransport extends Transport {
         if (this.silent) return done(null, true);
         let meta = prepareMeta(info);
 
-        let method = info.message === 'error' ? 'captureException' : 'captureMessage';
+        let method = info.message instanceof Error ? 'captureException' : 'captureMessage';
 
         try {
             let eventId = await this.raven[method](info.message, meta);


### PR DESCRIPTION
Hi,

I’ve fixed typo in the readme file and there's a bug in the comparison to string 'error'.

Thanks!